### PR TITLE
[WEBSITE-2149] Change 'Add to address book' link text

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -152,7 +152,7 @@ en:
     fax: 'fax'
     address: 'address'
     download: 'download'
-    add_address_book: 'add to address book'
+    add_address_book: 'download and add to address book'
   # constituencies translations
   constituencies:
     index:

--- a/spec/views/constituencies/contact_points/index.haml_spec.rb
+++ b/spec/views/constituencies/contact_points/index.haml_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe 'constituencies/contact_points/index', vcr: true do
 
   context 'links' do
     it 'will render link to contact_point_path' do
-      expect(rendered).to have_link('Add to address book', href: contact_point_path('8ONg5lY6'))
+      expect(rendered).to have_link('Download and add to address book', href: contact_point_path('8ONg5lY6'))
     end
   end
 end

--- a/spec/views/contact_points/index.html.haml_spec.rb
+++ b/spec/views/contact_points/index.html.haml_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe 'contact_points/index', vcr: true do
     end
 
     it 'will render link' do
-      expect(rendered).to have_link('Add to address book', href: contact_point_path('8ONg5lY6'))
+      expect(rendered).to have_link('Download and add to address book', href: contact_point_path('8ONg5lY6'))
     end
   end
 end

--- a/spec/views/people/contact_points/index.html.haml_spec.rb
+++ b/spec/views/people/contact_points/index.html.haml_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe 'people/contact_points/index', vcr: true do
 
   context 'links' do
     it 'will render link to contact_point_path' do
-      expect(rendered).to have_link('Add to address book', href: contact_point_path('8ONg5lY6'))
+      expect(rendered).to have_link('Download and add to address book', href: contact_point_path('8ONg5lY6'))
     end
   end
 end


### PR DESCRIPTION
I've changed it from 'Add to address book' to 'Download and add to address book'.